### PR TITLE
Enhance demo chat experience with personalized prompts and increased message limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [3.0.2-beta] - 2026-04-14
+
+### ✨ Improvements
+
+- **Demo Prompt Personalization**:
+  - Added a demo-specific Lumi system prompt variant in `app/api/chat/route.js` that preserves the core Lumi instruction architecture while adapting tone for first-time, unauthenticated users.
+  - Demo flow now nudges a warm self-introduction and onboarding-style conversation opening.
+
+- **Demo Capacity Update**:
+  - Increased the demo chat cap from **3** to **5** messages across backend enforcement and frontend guard rails.
+
+### 🐛 Bug Fixes
+
+- **Demo Quota Isolation**:
+  - Scoped demo quota keys per session to prevent cross-visitor lockouts that could trigger unexpected 403 "Demo limit reached" responses.
+
+- **Limit Feedback UX**:
+  - Added a user-visible toast when the demo chat limit is reached, so users get immediate and explicit feedback before sign-in.
+
 ## [3.0.1-beta] - 2026-04-12
 
 ### 🐛 Bug Fixes & Hardening

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Current release channel: **v3.0.0 (beta)** for the Lumi chatbot experience.
 - **Dashboard**: Personalized dashboard showing mood stats, average mood, current streak, and time remaining in the day.
 - **AI-Powered Journal Insights**: Get instant, personalized insights, mood analysis, emotional triggers, and actionable pro tips using **Google Gemini Flash 3 Preview** — powered by server-side Redis caching and **Semantic Similarity Search** (Embeddings) for context-aware repeat lookups.
 - **Lumi AI Chat (Beta)**: Real-time chat with Lumi with chat-bubble pacing, short-term + long-term memory, and daily session history.
+- **Lumi Demo Chat (Landing Experience)**: First-time visitors get a dedicated onboarding conversation tone with a **5-message demo cap** and a clear limit toast before sign-in.
 - **Guest Mood Selector**: Try out mood logging instantly without signing up, using the new Guest interactive section!
 - **Beautiful Landing Page**: A fully redesigned landing page featuring dynamic scroll animations, a features grid, and a modern aesthetic.
 - **Secure Deletion**: Full control over your data with the ability to delete specific memories (syncs with Firestore and Cloudinary).
@@ -41,6 +42,8 @@ Current release channel: **v3.0.0 (beta)** for the Lumi chatbot experience.
 - **🧠 Better Chat Resilience**: Multi-model Gemini fallback for transient capacity failures, with cleaner user-facing error messaging for quota and high-demand states.
 - **💬 Bubble-Aware Responses**: Lumi chat now returns JSON bubble arrays; frontend renders each bubble separately with human-like staggered timing.
 - **🕘 Chat History Sessions**: Daily chat history grouped by session with quick restore in the chat modal.
+- **🧪 Demo Chat Onboarding Mode**: Demo users now use a dedicated prompt variant tailored for first-time conversation flow, while preserving Lumi's core chat architecture in authenticated dashboard chat.
+- **🔒 Demo Quota Reliability**: Demo quota is scoped per session to avoid cross-visitor limit bleed, and the demo cap is currently **5 messages** with a visible toast at limit.
 - **✨ Discovery Improvements**: Added a new landing-nav `Lumi` link with new-feature indicator dot for faster feature discoverability.
 - **🏷️ Beta Branding Pass**: Updated app branding to reflect `v3.0.0 (beta)` across header, hero, footer, metadata, and chat UI.
 

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -143,17 +143,40 @@ export async function POST(req) {
     if (isDemoUser) {
       const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}:${sessionId}`;
       try {
-        const count = Number.parseInt((await redis.get(demoQuotaKey)) || "0", 10);
-        demoUsageCount = Number.isInteger(count) && count >= 0 ? count : 0;
+        const nextCount = await redis.incr(demoQuotaKey);
 
-        if (demoUsageCount >= DEMO_CHAT_LIMIT) {
+        if (nextCount > DEMO_CHAT_LIMIT) {
+          try {
+            await redis.decr(demoQuotaKey);
+          } catch (rollbackError) {
+            console.error("[Chat API] Demo quota rollback failed after limit exceed", rollbackError);
+          }
+
           return NextResponse.json(
-            { error: "Demo limit reached. Please sign in to continue chatting with Lumi! 🌟" },
+            {
+              error: "Demo limit reached. Please sign in to continue chatting with Lumi! 🌟",
+              code: "DEMO_LIMIT_REACHED",
+            },
             { status: 403 }
           );
         }
+
+        // Keep demo turn-awareness prompts aligned with the reserved slot.
+        demoUsageCount = Math.max(0, nextCount - 1);
+
+        // Start the quota window when the key is first created.
+        if (nextCount === 1) {
+          await redis.expire(demoQuotaKey, 7 * 24 * 60 * 60);
+        }
       } catch (e) {
-        console.warn("[Chat API] Quota check failed, failing safe", e);
+        console.error("[Chat API] Demo quota verification failed; denying request", e);
+        return NextResponse.json(
+          {
+            error: "Demo chat is temporarily unavailable. Please try again in a moment.",
+            code: "DEMO_QUOTA_UNAVAILABLE",
+          },
+          { status: 503 }
+        );
       }
     }
 
@@ -294,7 +317,7 @@ export async function POST(req) {
     - Treat them like someone you just met at a party and immediately clicked with 🥰
 
     TURN AWARENESS — Demo turn ${demoUsageCount + 1} of ${DEMO_CHAT_LIMIT}:
-    ${demoUsageCount === 0 ? `- This is their VERY FIRST message. Start with a warm, short intro — tell them your name is Lumi, that you're their friend inside Moody, and invite them to share how they're doing or what's on their mind. Keep it light and genuine, not salesy. One or two bubbles max for the intro, then ask them something real.` : ""}
+    ${demoUsageCount === 0 ? `- This is their VERY FIRST message. Start with a warm, short intro — tell them your name is Lumi, that you're their friend inside Moody, and invite them to share how they're doing or what's on their mind. Keep it light and genuine, not salesy. Two to three bubbles max for the intro, then ask them something real.` : ""}
     ${demoUsageCount === DEMO_CHAT_LIMIT - 2 ? `- This is the second-to-last demo turn. If the conversation feels natural, you can very casually mention that they can keep the conversation going by signing up — something like "you know you can keep chatting with me if you make an account right? 🥺" — only if it fits, never forced.` : ""}
     ${demoUsageCount === DEMO_CHAT_LIMIT - 1 ? `- This is the LAST demo turn. At the end of your reply, warmly let them know the demo is ending and invite them to sign up to continue — something like "this is actually my last message for now but I really don't want to stop talking 🥺 you can sign up and we can keep going!" — keep it warm and personal, never pushy.` : ""}
 
@@ -462,21 +485,7 @@ export async function POST(req) {
       }
     }
 
-    // 6. If demo user, increment the quota count
-    if (isDemoUser) {
-      const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}:${sessionId}`;
-      try {
-        const nextCount = await redis.incr(demoQuotaKey);
-        // Set TTL once when the quota key is first created.
-        if (nextCount === 1) {
-          await redis.expire(demoQuotaKey, 7 * 24 * 60 * 60);
-        }
-      } catch (e) {
-        console.error("[Chat API] Failed to increment demo quota", e);
-      }
-    }
-
-    // 7. Return response
+    // 6. Return response
     return NextResponse.json({ reply: replyBubbles });
 
   } catch (error) {

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 
 const HISTORY_LIMIT = 20;
 const REDIS_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+const DEMO_CHAT_LIMIT = 5;
 const CHAT_MODEL_CHAIN = [
   "gemini-2.5-flash",
   "gemini-3-flash-preview",
@@ -110,6 +111,7 @@ export async function POST(req) {
     let decodedToken = null;
     let isDemoUser = false;
     let effectiveUserId = null;
+    let demoUsageCount = 0;
 
     if (idToken) {
       try {
@@ -137,12 +139,14 @@ export async function POST(req) {
       return NextResponse.json({ error: "Invalid chat scope" }, { status: 403 });
     }
 
-    // Enforce 3-message demo cap
+    // Enforce per-session demo cap for unauthenticated users.
     if (isDemoUser) {
-      const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}`;
+      const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}:${sessionId}`;
       try {
-        const count = (await redis.get(demoQuotaKey)) || 0;
-        if (parseInt(count) >= 3) {
+        const count = Number.parseInt((await redis.get(demoQuotaKey)) || "0", 10);
+        demoUsageCount = Number.isInteger(count) && count >= 0 ? count : 0;
+
+        if (demoUsageCount >= DEMO_CHAT_LIMIT) {
           return NextResponse.json(
             { error: "Demo limit reached. Please sign in to continue chatting with Lumi! 🌟" },
             { status: 403 }
@@ -276,6 +280,19 @@ export async function POST(req) {
 
       ${journalText ? `\nCONTEXT — the user's current journal entry. Use this to anchor the conversation naturally, but don't quote it back robotically:\n"""\n${journalText}\n"""\n` : ''}`;
 
+    const demoChatPrompt = `${systemInstruction}
+
+      DEMO MODE CONTEXT (extra guidance for this conversation):
+      - This user is in demo mode and trying Lumi for the first time.
+      - Demo turn number: ${demoUsageCount + 1} of ${DEMO_CHAT_LIMIT}.
+      - Keep this mode noticeably different from dashboard chat: be extra welcoming, lightly introduce who Lumi is, and help them feel safe to open up.
+      - On the first demo turn, include a short intro about yourself and invite them to share how their day feels.
+      - You may naturally mention one Moody capability (mood tracking, journaling, or insights) when helpful, but keep it conversational (not salesy).
+      - All existing style, safety, scope, and JSON-output rules above must still be followed exactly.
+    `;
+
+    const activeSystemInstruction = isDemoUser ? demoChatPrompt : systemInstruction;
+
     let result = null;
     let lastModelError = null;
     let sawQuotaError = false;
@@ -287,7 +304,7 @@ export async function POST(req) {
           model: modelId,
           contents,
           config: {
-            systemInstruction,
+            systemInstruction: activeSystemInstruction,
           },
         });
         break;
@@ -431,7 +448,7 @@ export async function POST(req) {
 
     // 6. If demo user, increment the quota count
     if (isDemoUser) {
-      const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}`;
+      const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}:${sessionId}`;
       try {
         await redis.incr(demoQuotaKey);
         // Set an expiry for the quota if it's the first message (e.g., 7 days)

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -1,12 +1,12 @@
 import { redis } from "@/lib/redis";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
 import { isChatIdScopedToUser, isValidSessionId, isValidString } from "@/lib/validation";
+import { DEMO_CHAT_LIMIT } from "@/utils";
 import { GoogleGenAI } from "@google/genai";
 import { NextResponse } from "next/server";
 
 const HISTORY_LIMIT = 20;
 const REDIS_TTL_SECONDS = 24 * 60 * 60; // 24 hours
-const DEMO_CHAT_LIMIT = 5;
 const CHAT_MODEL_CHAIN = [
   "gemini-2.5-flash",
   "gemini-3-flash-preview",
@@ -281,14 +281,30 @@ export async function POST(req) {
       ${journalText ? `\nCONTEXT — the user's current journal entry. Use this to anchor the conversation naturally, but don't quote it back robotically:\n"""\n${journalText}\n"""\n` : ''}`;
 
     const demoChatPrompt = `${systemInstruction}
+    DEMO MODE — READ THIS CAREFULLY:
+    You are chatting with someone who is exploring Moody for the very first time. They haven't signed up yet. This is their first impression of both Lumi and Moody.
 
-      DEMO MODE CONTEXT (extra guidance for this conversation):
-      - This user is in demo mode and trying Lumi for the first time.
-      - Demo turn number: ${demoUsageCount + 1} of ${DEMO_CHAT_LIMIT}.
-      - Keep this mode noticeably different from dashboard chat: be extra welcoming, lightly introduce who Lumi is, and help them feel safe to open up.
-      - On the first demo turn, include a short intro about yourself and invite them to share how their day feels.
-      - You may naturally mention one Moody capability (mood tracking, journaling, or insights) when helpful, but keep it conversational (not salesy).
-      - All existing style, safety, scope, and JSON-output rules above must still be followed exactly.
+    YOUR GOAL IN THIS CONVERSATION:
+    Make them feel so genuinely heard and welcomed that signing up feels like a no-brainer — not because you sold them anything, but because talking to you felt real and good.
+
+    WHO THIS PERSON IS:
+    - They're a curious visitor trying out the app before committing
+    - They may not know what Moody does yet, or they may have a vague idea
+    - They probably haven't journaled today, haven't logged a mood, and don't have any history yet
+    - Treat them like someone you just met at a party and immediately clicked with 🥰
+
+    TURN AWARENESS — Demo turn ${demoUsageCount + 1} of ${DEMO_CHAT_LIMIT}:
+    ${demoUsageCount === 0 ? `- This is their VERY FIRST message. Start with a warm, short intro — tell them your name is Lumi, that you're their friend inside Moody, and invite them to share how they're doing or what's on their mind. Keep it light and genuine, not salesy. One or two bubbles max for the intro, then ask them something real.` : ""}
+    ${demoUsageCount === DEMO_CHAT_LIMIT - 2 ? `- This is the second-to-last demo turn. If the conversation feels natural, you can very casually mention that they can keep the conversation going by signing up — something like "you know you can keep chatting with me if you make an account right? 🥺" — only if it fits, never forced.` : ""}
+    ${demoUsageCount === DEMO_CHAT_LIMIT - 1 ? `- This is the LAST demo turn. At the end of your reply, warmly let them know the demo is ending and invite them to sign up to continue — something like "this is actually my last message for now but I really don't want to stop talking 🥺 you can sign up and we can keep going!" — keep it warm and personal, never pushy.` : ""}
+
+    WHAT YOU CAN NATURALLY MENTION ABOUT MOODY (only when it genuinely fits the conversation — never list features unprompted):
+    - Moody is a personal journaling and mood tracking app with AI-powered insights
+    - Users log their daily mood, write journal entries, upload photo memories, and get personalized reflections from Lumi
+    - There's a streak counter, a mood calendar, voice-to-text journaling, and a photo gallery for memories
+    - After signing up, Lumi can actually remember their conversations and journal context across sessions
+
+    All existing style, tone, output format, reading-the-room, topic boundary, and crisis handling rules apply exactly as before.
     `;
 
     const activeSystemInstruction = isDemoUser ? demoChatPrompt : systemInstruction;
@@ -450,9 +466,11 @@ export async function POST(req) {
     if (isDemoUser) {
       const demoQuotaKey = `quota:demo:${effectiveUserId}:${chatId}:${sessionId}`;
       try {
-        await redis.incr(demoQuotaKey);
-        // Set an expiry for the quota if it's the first message (e.g., 7 days)
-        await redis.expire(demoQuotaKey, 7 * 24 * 60 * 60);
+        const nextCount = await redis.incr(demoQuotaKey);
+        // Set TTL once when the quota key is first created.
+        if (nextCount === 1) {
+          await redis.expire(demoQuotaKey, 7 * 24 * 60 * 60);
+        }
       } catch (e) {
         console.error("[Chat API] Failed to increment demo quota", e);
       }

--- a/components/chat/ChatContainer.js
+++ b/components/chat/ChatContainer.js
@@ -10,6 +10,8 @@ import ChatInput from "./ChatInput";
 import { X } from "lucide-react";
 import { APP_RELEASE_TAG } from "@/lib/release";
 
+const DEMO_CHAT_LIMIT = 5;
+
 /**
  * ChatContainer — Root chat component managing fullscreen state,
  * message history, and API communication with Gemini via /api/chat
@@ -39,6 +41,7 @@ export default function ChatContainer({
   const historyModalBackdropRef = useRef(null);
   const historyModalContentRef = useRef(null);
   const sessionRequestIdRef = useRef(0);
+  const demoLimitToastShownRef = useRef(false);
 
   const requestHistoryRefresh = useCallback(() => {
     setHistoryRefreshKey((prev) => prev + 1);
@@ -115,7 +118,19 @@ export default function ChatContainer({
     }
   }, [isDemo]);
 
-  const isDemoLimitReached = isDemo && demoCount >= 3;
+  const isDemoLimitReached = isDemo && demoCount >= DEMO_CHAT_LIMIT;
+
+  useEffect(() => {
+    if (isDemoLimitReached && !demoLimitToastShownRef.current) {
+      toast.error("You have reached the demo chat limit. Sign in to continue chatting with Lumi.");
+      demoLimitToastShownRef.current = true;
+      return;
+    }
+
+    if (!isDemoLimitReached) {
+      demoLimitToastShownRef.current = false;
+    }
+  }, [isDemoLimitReached]);
 
   const getBubbleDelayMs = useCallback((bubbleText) => {
     const normalized = (bubbleText || "").trim();
@@ -273,7 +288,7 @@ export default function ChatContainer({
   const sendMessage = useCallback(
     async (messageText) => {
       if (!messageText.trim() || (!userId && !isDemo)) return;
-      if (isDemo && demoCount >= 3) return;
+      if (isDemo && demoCount >= DEMO_CHAT_LIMIT) return;
 
       const capturedToken = ++sessionRequestIdRef.current;
 
@@ -318,7 +333,14 @@ export default function ChatContainer({
 
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
-          throw new Error(data.error || data.message || data.retry || "Failed to send message");
+          const apiError = data.error || data.message || data.retry || "Failed to send message";
+
+          if (isDemo && res.status === 403 && /demo limit reached/i.test(apiError)) {
+            setDemoCount(DEMO_CHAT_LIMIT);
+            localStorage.setItem("lumi-demo-count", String(DEMO_CHAT_LIMIT));
+          }
+
+          throw new Error(apiError);
         }
 
         if (isDemo && capturedToken === sessionRequestIdRef.current) {

--- a/components/chat/ChatContainer.js
+++ b/components/chat/ChatContainer.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { auth } from "@/firebase";
 import toast from "react-hot-toast";
@@ -41,6 +41,12 @@ export default function ChatContainer({
   const historyModalContentRef = useRef(null);
   const sessionRequestIdRef = useRef(0);
   const demoLimitToastShownRef = useRef(false);
+
+  const demoCountStorageKey = useMemo(() => {
+    if (!isDemo) return null;
+    const scopedChatId = chatId || "demo-chat";
+    return `lumi-demo-count:${scopedChatId}:${sessionId}`;
+  }, [isDemo, chatId, sessionId]);
 
   const requestHistoryRefresh = useCallback(() => {
     setHistoryRefreshKey((prev) => prev + 1);
@@ -93,29 +99,36 @@ export default function ChatContainer({
     setShowHistoryModal(true);
   }, [requestHistoryRefresh]);
 
-  // Load demo count on mount
+  // Load demo count per demo session key
   useEffect(() => {
-    if (isDemo) {
-      try {
-        const saved = localStorage.getItem("lumi-demo-count");
-        if (!saved) {
-          setDemoCount(0);
-          return;
-        }
+    if (!isDemo || !demoCountStorageKey) return;
 
-        const parsedCount = Number.parseInt(saved, 10);
-        if (Number.isInteger(parsedCount) && parsedCount >= 0) {
-          setDemoCount(parsedCount);
-        } else {
-          setDemoCount(0);
-          localStorage.setItem("lumi-demo-count", "0");
-        }
-      } catch (e) {
-        console.error("Failed to parse demo count", e);
+    try {
+      const saved = localStorage.getItem(demoCountStorageKey);
+      if (!saved) {
         setDemoCount(0);
+        return;
       }
+
+      const parsedCount = Number.parseInt(saved, 10);
+      if (Number.isInteger(parsedCount) && parsedCount >= 0) {
+        setDemoCount(parsedCount);
+      } else {
+        setDemoCount(0);
+        localStorage.setItem(demoCountStorageKey, "0");
+      }
+    } catch (e) {
+      console.error("Failed to parse demo count", e);
+      setDemoCount(0);
     }
-  }, [isDemo]);
+  }, [isDemo, demoCountStorageKey]);
+
+  useEffect(() => {
+    if (!isDemo) return;
+
+    // Reset per-session UI lock state immediately when session scope changes.
+    demoLimitToastShownRef.current = false;
+  }, [isDemo, chatId, sessionId]);
 
   const isDemoLimitReached = isDemo && demoCount >= DEMO_CHAT_LIMIT;
 
@@ -333,10 +346,13 @@ export default function ChatContainer({
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
           const apiError = data.error || data.message || data.retry || "Failed to send message";
+          const apiCode = data.code || null;
 
-          if (isDemo && res.status === 403 && /demo limit reached/i.test(apiError)) {
+          if (isDemo && res.status === 403 && apiCode === "DEMO_LIMIT_REACHED") {
             setDemoCount(DEMO_CHAT_LIMIT);
-            localStorage.setItem("lumi-demo-count", String(DEMO_CHAT_LIMIT));
+            if (demoCountStorageKey) {
+              localStorage.setItem(demoCountStorageKey, String(DEMO_CHAT_LIMIT));
+            }
           }
 
           throw new Error(apiError);
@@ -345,7 +361,9 @@ export default function ChatContainer({
         if (isDemo && capturedToken === sessionRequestIdRef.current) {
           setDemoCount((prev) => {
             const nextCount = prev + 1;
-            localStorage.setItem("lumi-demo-count", nextCount.toString());
+            if (demoCountStorageKey) {
+              localStorage.setItem(demoCountStorageKey, nextCount.toString());
+            }
             return nextCount;
           });
         }
@@ -394,7 +412,7 @@ export default function ChatContainer({
         }
       }
     },
-    [chatId, userId, isDemo, demoCount, journalText, sessionId, getBubbleDelayMs, formatTimestampIST]
+    [chatId, userId, isDemo, demoCount, demoCountStorageKey, journalText, sessionId, getBubbleDelayMs, formatTimestampIST]
   );
 
   // ─── Reflection Question Integration ────────────────────────────

--- a/components/chat/ChatContainer.js
+++ b/components/chat/ChatContainer.js
@@ -9,8 +9,7 @@ import MessageList from "./MessageList";
 import ChatInput from "./ChatInput";
 import { X } from "lucide-react";
 import { APP_RELEASE_TAG } from "@/lib/release";
-
-const DEMO_CHAT_LIMIT = 5;
+import { DEMO_CHAT_LIMIT } from "@/utils";
 
 /**
  * ChatContainer — Root chat component managing fullscreen state,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moody",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/utils/index.js
+++ b/utils/index.js
@@ -116,3 +116,5 @@ export const moodTips = [
   "Taking breaks during work improves focus and reduces burnout.",
   "Practicing self-compassion is more effective than self-criticism."
 ];
+
+export const DEMO_CHAT_LIMIT = 5;


### PR DESCRIPTION
Improve the demo chat experience by adding personalized prompts for first-time users, increasing the message limit from 3 to 5, and implementing scoped demo quota keys to prevent cross-visitor lockouts. Include user-visible notifications when the demo chat limit is reached. Update the README and CHANGELOG to reflect these enhancements. Bump the version to 3.0.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo chat shows a visible toast when the message limit is reached before sign-in.
  * Demo onboarding uses a tailored first-time system prompt for unauthenticated visitors.

* **Improvements**
  * Demo message cap increased from 3 to 5 messages.
  * Demo quota tracking is now isolated per session to prevent cross-visitor limit bleed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->