### PR TITLE
Add telemetry metrics and daily insights tracking utility

### DIFF
--- a/app/actions/insights.js
+++ b/app/actions/insights.js
@@ -1,6 +1,7 @@
 "use server";
 
 import { redis } from "@/lib/redis";
+import { incrementMetric } from "@/lib/metrics";
 import { GoogleGenAI } from "@google/genai";
 import { getAdminAuth } from "@/lib/firebase-admin";
 import crypto from 'node:crypto';
@@ -470,6 +471,7 @@ export async function generateInsight(idToken, journalText, forceRegenerate = fa
         item.sourceText === normalizedJournalText &&
         item.response
       ) {
+        void incrementMetric("cache_hit_exact_phase0");
         return { success: true, data: item.response, modelUsed: "cache" };
       }
     }
@@ -562,6 +564,7 @@ export async function generateInsight(idToken, journalText, forceRegenerate = fa
       }
 
       if (exactCacheData) {
+        void incrementMetric("cache_hit_exact");
         return { success: true, data: exactCacheData, modelUsed: "cache" };
       }
 
@@ -569,6 +572,7 @@ export async function generateInsight(idToken, journalText, forceRegenerate = fa
         if (hasValidPartialCacheSeed(bestMatch.response)) {
           isCacheHit = true;
           cachedData = bestMatch.response;
+          void incrementMetric("cache_hit_partial");
         } else {
           isCacheHit = false;
           cachedData = null;
@@ -682,12 +686,17 @@ export async function generateInsight(idToken, journalText, forceRegenerate = fa
         };
       } else {
         insight = parsed;
+        void incrementMetric("full_generation");
       }
 
       modelUsed = modelId;
       break;
     } catch (error) {
       console.error(`[Insights] ${modelLabel} error:`, error.message);
+
+      if (error.message?.includes("Validation Failed")) {
+        void incrementMetric("schema_validation_failed");
+      }
 
       if (isRetryableError(error)) {
         if (isQuotaError(error)) await markModelExhausted(modelId);

--- a/app/actions/insights.js
+++ b/app/actions/insights.js
@@ -471,7 +471,7 @@ export async function generateInsight(idToken, journalText, forceRegenerate = fa
         item.sourceText === normalizedJournalText &&
         item.response
       ) {
-        void incrementMetric("cache_hit_exact_phase0");
+        await incrementMetric("cache_hit_exact_phase0");
         return { success: true, data: item.response, modelUsed: "cache" };
       }
     }
@@ -564,7 +564,7 @@ export async function generateInsight(idToken, journalText, forceRegenerate = fa
       }
 
       if (exactCacheData) {
-        void incrementMetric("cache_hit_exact");
+        await incrementMetric("cache_hit_exact");
         return { success: true, data: exactCacheData, modelUsed: "cache" };
       }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,59 @@
+import { redis } from "@/lib/redis";
+
+const METRICS_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+function istDate() {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Kolkata",
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  const partMap = {};
+  for (const part of formatter.formatToParts(now)) {
+    if (part.type !== "literal") {
+      partMap[part.type] = Number(part.value);
+    }
+  }
+
+  const hasAllParts = ["year", "month", "day", "hour", "minute", "second"]
+    .every((key) => Number.isFinite(partMap[key]));
+
+  if (!hasAllParts) {
+    return "unknown";
+  }
+
+  const istTime = new Date(Date.UTC(
+    partMap.year,
+    partMap.month - 1,
+    partMap.day,
+    partMap.hour,
+    partMap.minute,
+    partMap.second
+  ));
+  return istTime.toISOString().slice(0, 10);
+}
+
+/**
+ * Increments a daily insights metric without affecting the caller on Redis failures.
+ * @param {string} name Metric name.
+ * @returns {Promise<void>}
+ */
+export async function incrementMetric(name) {
+  try {
+    const key = `metrics:insights:${name}:${istDate()}`;
+    const count = await redis.incr(key);
+
+    if (count === 1) {
+      await redis.expire(key, METRICS_TTL_SECONDS);
+    }
+  } catch (error) {
+    console.error("[Metrics] Failed to increment insights metric:", error?.message || error);
+  }
+}

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -2,6 +2,7 @@ import { redis } from "@/lib/redis";
 
 const METRICS_TTL_SECONDS = 35 * 24 * 60 * 60;
 
+// Asia/Kolkata defines the product reporting day; metrics do not use per-user timezones.
 function istDate() {
   const now = new Date();
   const formatter = new Intl.DateTimeFormat("en-US", {
@@ -48,11 +49,14 @@ function istDate() {
 export async function incrementMetric(name) {
   try {
     const key = `metrics:insights:${name}:${istDate()}`;
-    const count = await redis.incr(key);
-
-    if (count === 1) {
-      await redis.expire(key, METRICS_TTL_SECONDS);
-    }
+    const script = `
+      local count = redis.call("INCR", KEYS[1])
+      if count == 1 then
+        redis.call("EXPIRE", KEYS[1], ARGV[1])
+      end
+      return count
+    `;
+    await redis.eval(script, [key], [METRICS_TTL_SECONDS]);
   } catch (error) {
     console.error("[Metrics] Failed to increment insights metric:", error?.message || error);
   }


### PR DESCRIPTION
This pull request adds a new metrics tracking system for the insights generation process, allowing cache hits, cache misses, and validation failures to be logged in Redis for analysis. The main changes include introducing a `metrics.js` utility, instrumenting the insights generation logic with metric counters, and ensuring metrics are tracked per day in IST (Indian Standard Time).

**Metrics tracking enhancements:**

* Added new `lib/metrics.js` module with an `incrementMetric` function that increments daily metrics in Redis, using IST for date partitioning and robust error handling.

**Instrumentation of insights generation:**

* Updated `app/actions/insights.js` to import and use `incrementMetric` for tracking:
  * Exact cache hits in phase 0 (`cache_hit_exact_phase0`).
  * Exact cache hits (`cache_hit_exact`).
  * Partial cache hits (`cache_hit_partial`).
  * Full generations (`full_generation`).
  * Schema validation failures (`schema_validation_failed`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily tracking for insight generation outcomes, including exact and partial cache hits, full generations, and validation failures.
  * Metrics are retained for 35 days to support trend analysis.

* **Reliability**
  * Metrics collection failures are handled without interrupting insight generation.
  * Added timezone-aware daily reporting for more consistent metric tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds daily IST-partitioned Redis counters for cache outcomes, successful full generations, and schema-validation failures.
- Introduces a reusable metrics utility with 35-day key retention and error isolation.
- Instruments the insights generation and cache-selection paths with telemetry calls.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Redis expiration failure path should be fixed before merging because it can leave telemetry keys permanently retained; the untracked metric promises are an additional non-blocking reliability concern.

A successful first increment followed by a failed expiration leaves a key with no TTL, and all later increments skip expiration; separately, immediate-return cache branches do not ensure their asynchronous metric requests complete.

**Files Needing Attention:** lib/metrics.js and app/actions/insights.js
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/metrics.js | Adds daily Redis counters, but a failed initial EXPIRE permanently bypasses the intended retention policy. |
| app/actions/insights.js | Adds counters at major cache and generation outcomes, but discards their promises without tying them to the server-action lifecycle. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Insights as generateInsight
    participant Metrics as incrementMetric
    participant Redis
    Client->>Insights: Generate insight
    alt Cache hit
        Insights--)Metrics: Increment cache metric
        Metrics->>Redis: INCR daily key
        opt First increment
            Metrics->>Redis: EXPIRE 35 days
        end
        Insights-->>Client: Cached response
    else Full generation
        Insights--)Metrics: Increment generation metric
        Metrics->>Redis: INCR daily key
        Insights-->>Client: Generated response
    end
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aditya-2k23%2Fmoody%22%20on%20the%20existing%20branch%20%22codex%2Finsights-redis-metrics%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Finsights-redis-metrics%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fmetrics.js%3A53-54%0A**Expiration%20failure%20leaves%20permanent%20keys**%0A%0AWhen%20the%20first%20%60INCR%60%20succeeds%20but%20the%20separate%20%60EXPIRE%60%20request%20fails%2C%20the%20new%20key%20remains%20without%20a%20TTL.%20Later%20increments%20return%20values%20greater%20than%201%20and%20never%20retry%20expiration%2C%20causing%20that%20daily%20metrics%20key%20to%20persist%20indefinitely%20instead%20of%20respecting%20the%2035-day%20retention%20period.%0A%0A%23%23%23%20Issue%202%0Aapp%2Factions%2Finsights.js%3A471-472%0A**Metric%20promises%20outlive%20request%20lifecycle**%0A%0AIf%20the%20deployment%20suspends%20request%20execution%20after%20a%20server%20action%20returns%2C%20discarding%20the%20%60incrementMetric%60%20promise%20allows%20its%20Upstash%20request%20to%20be%20interrupted.%20The%20immediate-return%20cache%20branches%20are%20especially%20exposed%2C%20causing%20telemetry%20events%20to%20be%20silently%20omitted%20from%20the%20daily%20totals.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aditya-2k23%2Fmoody&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fmetrics.js%3A53-54%0A**Expiration%20failure%20leaves%20permanent%20keys**%0A%0AWhen%20the%20first%20%60INCR%60%20succeeds%20but%20the%20separate%20%60EXPIRE%60%20request%20fails%2C%20the%20new%20key%20remains%20without%20a%20TTL.%20Later%20increments%20return%20values%20greater%20than%201%20and%20never%20retry%20expiration%2C%20causing%20that%20daily%20metrics%20key%20to%20persist%20indefinitely%20instead%20of%20respecting%20the%2035-day%20retention%20period.%0A%0A%23%23%23%20Issue%202%0Aapp%2Factions%2Finsights.js%3A471-472%0A**Metric%20promises%20outlive%20request%20lifecycle**%0A%0AIf%20the%20deployment%20suspends%20request%20execution%20after%20a%20server%20action%20returns%2C%20discarding%20the%20%60incrementMetric%60%20promise%20allows%20its%20Upstash%20request%20to%20be%20interrupted.%20The%20immediate-return%20cache%20branches%20are%20especially%20exposed%2C%20causing%20telemetry%20events%20to%20be%20silently%20omitted%20from%20the%20daily%20totals.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aditya-2k23%2Fmoody&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/metrics.js:53-54
**Expiration failure leaves permanent keys**

When the first `INCR` succeeds but the separate `EXPIRE` request fails, the new key remains without a TTL. Later increments return values greater than 1 and never retry expiration, causing that daily metrics key to persist indefinitely instead of respecting the 35-day retention period.

### Issue 2
app/actions/insights.js:471-472
**Metric promises outlive request lifecycle**

If the deployment suspends request execution after a server action returns, discarding the `incrementMetric` promise allows its Upstash request to be interrupted. The immediate-return cache branches are especially exposed, causing telemetry events to be silently omitted from the daily totals.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(metrics): add daily insights tracki..."](https://github.com/aditya-2k23/moody/commit/8c68a413cf9ed1307d0b53096b2d2d5fc857dac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49969424)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->